### PR TITLE
Update installation commands for Gemini CLI and Codex

### DIFF
--- a/docs/02-quickstart.md
+++ b/docs/02-quickstart.md
@@ -16,7 +16,7 @@ Get up and running with AI in the terminal in **5 minutes**.
 
 **Linux / macOS / WSL:**
 ```bash
-npm install -g @google/generative-ai-cli
+npm install -g @google/gemini-cli
 ```
 
 **macOS (Homebrew):**
@@ -26,7 +26,7 @@ brew install gemini-cli
 
 **Permission error?** Add `sudo`:
 ```bash
-sudo npm install -g @google/generative-ai-cli
+sudo npm install -g @google/gemini-cli
 ```
 
 ### Step 2: Create Project (10 seconds)

--- a/docs/03-gemini-cli.md
+++ b/docs/03-gemini-cli.md
@@ -22,12 +22,12 @@ Chuck's reasoning:
 
 ```bash
 # Install globally with npm
-npm install -g @google/generative-ai-cli
+npm install -g @google/gemini-cli
 ```
 
 **Permission error?** Run with sudo:
 ```bash
-sudo npm install -g @google/generative-ai-cli
+sudo npm install -g @google/gemini-cli
 ```
 
 ### macOS (Alternative with Homebrew)
@@ -419,7 +419,7 @@ Gemini can access ALL your Obsidian notes because they're just markdown files!
 
 ```bash
 # Use sudo
-sudo npm install -g @google/generative-ai-cli
+sudo npm install -g @google/gemini-cli
 ```
 
 ### "Command not found: gemini"

--- a/docs/05-codex.md
+++ b/docs/05-codex.md
@@ -18,7 +18,7 @@ Codex is OpenAI's terminal tool that brings ChatGPT to the command line.
 ## Installation
 
 ```bash
-npm install -g @openai/codex-cli
+npm install -g @openai/codex
 
 # Or follow official OpenAI documentation
 ```

--- a/docs/14-cheat-sheet.md
+++ b/docs/14-cheat-sheet.md
@@ -7,10 +7,10 @@ Quick reference for all AI terminal tools covered in the video.
 ### Gemini CLI
 ```bash
 # Linux/macOS/WSL (npm)
-npm install -g @google/generative-ai-cli
+npm install -g @google/gemini-cli
 
 # With sudo (if permission error)
-sudo npm install -g @google/generative-ai-cli
+sudo npm install -g @google/gemini-cli
 
 # macOS (Homebrew)
 brew install gemini-cli
@@ -28,7 +28,7 @@ sudo npm install -g @anthropic-ai/claude-code
 ### Codex (ChatGPT CLI)
 ```bash
 # Installation command
-npm install -g @openai/codex-cli
+npm install -g @openai/codex
 
 # Or follow OpenAI documentation
 ```
@@ -405,7 +405,7 @@ gemini
 ### Permission Issues
 ```bash
 # Reinstall with sudo
-sudo npm install -g @google/generative-ai-cli
+sudo npm install -g @google/gemini-cli
 
 # Fix permissions
 sudo chown -R $USER /usr/local/lib/node_modules
@@ -561,7 +561,7 @@ rm -rf ~/.config/claude-code
 rm -rf ~/.config/opencode
 
 # Reinstall
-npm install -g @google/generative-ai-cli
+npm install -g @google/gemini-cli
 npm install -g @anthropic-ai/claude-code
 curl -fsSL https://opencode.sh/install.sh | sh
 ```

--- a/docs/15-troubleshooting.md
+++ b/docs/15-troubleshooting.md
@@ -30,7 +30,7 @@ echo $PATH | grep npm
 **Solutions:**
 ```bash
 # Option 1: Use sudo (quick fix)
-sudo npm install -g @google/generative-ai-cli
+sudo npm install -g @google/gemini-cli
 
 # Option 2: Fix npm permissions (proper fix)
 sudo chown -R $USER /usr/local/lib/node_modules
@@ -350,7 +350,7 @@ nvm install --lts
 nvm use --lts
 
 # Now install tools
-npm install -g @google/generative-ai-cli
+npm install -g @google/gemini-cli
 ```
 
 ## Still Having Issues?
@@ -375,7 +375,7 @@ rm -rf ~/.config/claude-code
 rm -rf ~/.config/opencode
 
 # 2. Reinstall from scratch
-npm install -g @google/generative-ai-cli
+npm install -g @google/gemini-cli
 npm install -g @anthropic-ai/claude-code
 curl -fsSL https://opencode.sh/install.sh | sh
 


### PR DESCRIPTION
- Replaced references from `@google/generative-ai-cli` to `@google/gemini-cli` in multiple documentation files.
- Updated Codex installation command from `@openai/codex-cli` to `@openai/codex`.
- Ensured consistency across quickstart, cheat sheet, and troubleshooting guides.

This change reflects the latest naming conventions for the tools.